### PR TITLE
Feature: sorts group and direct chats in QChat

### DIFF
--- a/plugins/core/messaging/q-chat/q-chat.src.js
+++ b/plugins/core/messaging/q-chat/q-chat.src.js
@@ -366,10 +366,14 @@ class Chat extends LitElement {
 
     setChatHeads(chatObj) {
 
-        let groupList = chatObj.groups.map(group => group.groupId === 0 ? { groupId: group.groupId, url: `group/${group.groupId}`, groupName: "Qortal General Chat", timestamp: group.timestamp === undefined ? 1 : group.timestamp } : { ...group, url: `group/${group.groupId}` })
+        let groupList = chatObj.groups.map(group => group.groupId === 0 ? { groupId: group.groupId, url: `group/${group.groupId}`, groupName: "Qortal General Chat", timestamp: group.timestamp === undefined ? 2 : group.timestamp } : { ...group, timestamp: group.timestamp === undefined ? 1 : group.timestamp, url: `group/${group.groupId}` })
         let directList = chatObj.direct.map(dc => {
             return { ...dc, url: `direct/${dc.address}` }
         })
+        const compareNames = (a, b) => {
+            return a.groupName.localeCompare(b.groupName)
+        }
+        groupList.sort(compareNames)
         let chatHeadMasterList = [...groupList, ...directList]
 
         const compareArgs = (a, b) => {


### PR DESCRIPTION
single pull required.

empty groups have "undefined" timestamp, which was breaking the sorting.
when General Chat is empty, set timestamp to 2, other empty groups set to 1.
this causes empy General Chat to always come before other empty groups.

before concatenating groupList and directList, sort groups by name.
this sorting persists thru the sort by time, and causes all empty group to display alphabetically.
directs always have a timestamp or they would not be returned.

<img src="https://i.imgur.com/AeaqlWS.png">